### PR TITLE
Fix GitHub Actions publish workflows

### DIFF
--- a/.github/workflows/publish-to-cratesio.yml
+++ b/.github/workflows/publish-to-cratesio.yml
@@ -9,10 +9,14 @@ on:
         description: 'Version to publish (e.g., v1.0.0)'
         required: true
         type: string
+      dry_run:
+        description: 'Dry run (do not actually publish)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
-  contents: write
-  pull-requests: read
+  contents: read
 
 jobs:
   test-and-lint:
@@ -40,7 +44,7 @@ jobs:
           else
             VERSION="${{ github.event.release.tag_name }}"
           fi
-          echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
           echo "tag=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Verify version matches Cargo.toml
@@ -52,7 +56,14 @@ jobs:
           fi
 
 
+      - name: Dry run publish to crates.io
+        if: github.event.inputs.dry_run == 'true'
+        run: cargo publish --dry-run --token ${{ secrets.CRATES_TOKEN }}
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+
       - name: Publish to crates.io
+        if: github.event.inputs.dry_run == 'false' || github.event_name == 'release'
         run: cargo publish --token ${{ secrets.CRATES_TOKEN }}
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      version:
+        description: 'Version to publish (e.g., v1.0.0)'
+        required: true
+        type: string
       dry_run:
         description: 'Dry run (do not actually publish)'
         required: false
@@ -15,7 +19,11 @@ permissions:
   contents: read
 
 jobs:
+  test-and-lint:
+    uses: ./.github/workflows/test-and-lint.yml
+
   build-and-publish:
+    needs: test-and-lint
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -34,6 +42,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Get version from release or input
+        id: get_version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tag=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -104,7 +123,7 @@ jobs:
           npm publish --access public --dry-run
 
       - name: Publish platform package
-        if: github.event.inputs.dry_run == 'false'
+        if: github.event.inputs.dry_run == 'false' || github.event_name == 'release'
         run: |
           cd dist/${{ matrix.platform }}
           npm publish --access public
@@ -143,7 +162,7 @@ jobs:
           npm publish --access public --dry-run
 
       - name: Publish main package
-        if: github.event.inputs.dry_run == 'false'
+        if: github.event.inputs.dry_run == 'false' || github.event_name == 'release'
         run: |
           cd npm-dist/mocks
           npm publish --access public


### PR DESCRIPTION
## Summary

- Fixed critical issues in crates.io and npm publishing workflows
- Added dry run functionality for safe testing
- Improved version handling and conditional logic

## Changes

`publish-to-cratesio.yml`:

- Added dry_run input parameter for workflow dispatch testing
- Fixed permissions scope (reduced from contents: write to contents: read)
- Corrected version extraction logic (removed incorrect #v prefix removal)
- Added dry run step with proper conditional execution
- Fixed publish condition to handle both manual dispatch and release events

`publish-to-npm.yml`:
 
- Added missing version input parameter for manual workflow dispatch
- Added test-and-lint job dependency to ensure quality checks
- Implemented proper version extraction logic for both dispatch and release triggers
- Fixed conditional logic for publishing steps to work correctly with both dry run and release scenarios